### PR TITLE
Remove deprecated warning for IOHIKeyboardMapper included in IOHIKeyboard

### DIFF
--- a/Headers/IOKit/hidsystem/IOHIKeyboardMapper.h
+++ b/Headers/IOKit/hidsystem/IOHIKeyboardMapper.h
@@ -113,7 +113,7 @@ typedef struct _stickyKeys_ModifierInfo
 
 class IOHIDKeyboardDevice;
 
-class __kpi_deprecated ("Use DriverKit") IOHIKeyboardMapper : public OSObject
+class IOHIKeyboardMapper : public OSObject
 {
   OSDeclareDefaultStructors(IOHIKeyboardMapper);
 


### PR DESCRIPTION
Another usage of `__kpi_deprecated` is in [`IOHIDWorkLoop.h`](https://github.com/acidanthera/MacKernelSDK/blob/master/Headers/IOKit/hidsystem/IOHIDWorkLoop.h) included in [`IOHIDSystem.h`](https://github.com/acidanthera/MacKernelSDK/blob/master/Headers/IOKit/hidsystem/IOHIDSystem.h), while the latter one is rarely used. However, I wonder if we need to keep hunting for other "Use DriverKit" cases. However most of them are serial ones.

Update: just remove all of them at https://github.com/zhen-zen/MacKernelSDK/tree/driverkit-deprecated-warning