### PR TITLE
Deprecate strncpy, strncat, strcmp according to Apple's SDK

### DIFF
--- a/Headers/string.h
+++ b/Headers/string.h
@@ -72,17 +72,17 @@ extern size_t   strnlen(const char *, size_t);
 
 /* strcpy() is being deprecated. Please use strlcpy() instead. */
 extern char     *strcpy(char *, const char *) __deprecated;
-extern char     *strncpy(char *, const char *, size_t);
+extern char     *strncpy(char *, const char *, size_t) __deprecated;
 
 extern size_t   strlcat(char *, const char *, size_t);
 extern size_t   strlcpy(char *, const char *, size_t);
 
 /* strcat() is being deprecated. Please use strlcat() instead. */
 extern char     *strcat(char *, const char *) __deprecated;
-extern char     *strncat(char *, const char *, size_t);
+extern char     *strncat(char *, const char *, size_t) __deprecated;
 
 /* strcmp() is being deprecated. Please use strncmp() instead. */
-extern int      strcmp(const char *, const char *);
+extern int      strcmp(const char *, const char *) __deprecated;
 extern int      strncmp(const char *, const char *, size_t);
 
 extern int      strcasecmp(const char *s1, const char *s2);


### PR DESCRIPTION
Apple's SDK uses the `__kpi_deprecated_arm64_macos_unavailable` macro on those methods ([See here](https://github.com/alexey-lysiuk/macos-sdk/blob/master/MacOSX11.0.sdk/System/Library/Frameworks/Kernel.framework/Versions/A/Headers/string.h)), but it was removed from MacKernelSDK (Probably due to `arm64` being irrelevant).
However, this macro has a meaning for `x86_64` too.

From `sys/cdefs.h`:
```
#if TARGET_OS_OSX && defined(__arm64__)
#define __kpi_deprecated_arm64_macos_unavailable __unavailable
#else /* !TARGET_OS_OSX || !defined(__arm64__) */
#define __kpi_deprecated_arm64_macos_unavailable __deprecated
#endif /* !TARGET_OS_OSX || !defined(__arm64__) */
```

I didn't add anything to `README.md` as there's no functional change compared to the regular SDK.