### PR TITLE
Add constants and fix warnings for UNC

### DIFF
--- a/Headers/UserNotification/KUNCUserNotifications.h
+++ b/Headers/UserNotification/KUNCUserNotifications.h
@@ -50,7 +50,7 @@ KUNCUserNotificationDisplayNotice(
 	char            *localizationPath,
 	char            *alertHeader,
 	char            *alertMessage,
-	char            *defaultButtonTitle) __attribute__((deprecated));
+	char            *defaultButtonTitle);
 
 /*
  * ***BLOCKING*** alert call, returned int value corresponds to the
@@ -68,7 +68,7 @@ KUNCUserNotificationDisplayAlert(
 	char            *defaultButtonTitle,
 	char            *alternateButtonTitle,
 	char            *otherButtonTitle,
-	unsigned        *responseFlags) __attribute__((deprecated));
+	unsigned        *responseFlags);
 
 
 /*
@@ -87,7 +87,7 @@ kern_return_t
 KUNCExecute(
 	char    *executionPath,
 	int     openAsUser,
-	int     pathExecutionType) __attribute__((deprecated));
+	int     pathExecutionType);
 
 
 /* KUNC User Notification XML Keys
@@ -202,6 +202,25 @@ enum {
 	kKUNCCancelResponse         = 3
 };
 
+/*
+ * Flags for alert levels and buttons
+ *
+ * Check the constants defined in Core Foundation’s
+ * CFUserNotification for the constants to use.
+ */
+
+enum {
+    kKUNCStopAlertLevel         = 0,
+    kKUNCNoteAlertLevel         = 1,
+    kKUNCCautionAlertLevel      = 2,
+    kKUNCPlainAlertLevel        = 3
+};
+
+enum {
+    kKUNCNoDefaultButtonFlag    = (1UL << 5),
+    kKUNCUseRadioButtonsFlag    = (1UL << 6)
+};
+
 #define KUNCCheckBoxChecked(i)  (1 << (8 + i))   /* can be used for radio's too */
 #define KUNCPopUpSelection(n)   (n << 24)
 
@@ -217,7 +236,7 @@ typedef void
 /*
  * Get a notification ID
  */
-KUNCUserNotificationID KUNCGetNotificationID(void) __attribute__((deprecated));
+KUNCUserNotificationID KUNCGetNotificationID(void);
 
 /* This function currently requires a bundle path, which kexts cannot currently get.  In the future, the CFBundleIdentiofier of the kext will be pass in in place of the bundlePath. */
 
@@ -230,12 +249,12 @@ KUNCUserNotificationDisplayFromBundle(
 	char                            *messageKey,
 	char                            *tokenString,
 	KUNCUserNotificationCallBack    callback,
-	int                             contextKey) __attribute__((deprecated));
+	int                             contextKey);
 
 
 kern_return_t
 KUNCUserNotificationCancel(
-	KUNCUserNotificationID  notification) __attribute__((deprecated));
+	KUNCUserNotificationID  notification);
 
 
 __END_DECLS

--- a/Headers/UserNotification/KUNCUserNotifications.h
+++ b/Headers/UserNotification/KUNCUserNotifications.h
@@ -210,15 +210,15 @@ enum {
  */
 
 enum {
-    kKUNCStopAlertLevel         = 0,
-    kKUNCNoteAlertLevel         = 1,
-    kKUNCCautionAlertLevel      = 2,
-    kKUNCPlainAlertLevel        = 3
+	kKUNCStopAlertLevel         = 0,
+	kKUNCNoteAlertLevel         = 1,
+	kKUNCCautionAlertLevel      = 2,
+	kKUNCPlainAlertLevel        = 3
 };
 
 enum {
-    kKUNCNoDefaultButtonFlag    = (1UL << 5),
-    kKUNCUseRadioButtonsFlag    = (1UL << 6)
+	kKUNCNoDefaultButtonFlag    = (1UL << 5),
+	kKUNCUseRadioButtonsFlag    = (1UL << 6)
 };
 
 #define KUNCCheckBoxChecked(i)  (1 << (8 + i))   /* can be used for radio's too */

--- a/README.md
+++ b/README.md
@@ -100,3 +100,4 @@ To compile for 32-bit you will need to add a set of flags in your project:
     - In `net`, `netinit`, `network`, `sys` due to NKE KPI deprecation
     - In `hid`, `serial`, `usb` due to missing overrides and KPI deprecation in favor of `DriverKit`
     - In `OSUnserialize.h` due to `OSStringPtr` misuse
+    - In `KUNCUserNotifications.h` due to KPI deprecation


### PR DESCRIPTION
Additional constants are copied from [CFUserNotification.h](https://opensource.apple.com/source/CF/CF-1153.18/CFUserNotification.h) and renamed to match existing flags.