### PR TITLE
Sync loader.h and nlist.h with Xcode 14.3 SDK

### DIFF
--- a/Headers/mach-o/loader.h
+++ b/Headers/mach-o/loader.h
@@ -53,8 +53,8 @@
  */
 struct mach_header {
 	uint32_t	magic;		/* mach magic number identifier */
-	cpu_type_t	cputype;	/* cpu specifier */
-	cpu_subtype_t	cpusubtype;	/* machine specifier */
+	int32_t		cputype;	/* cpu specifier */
+	int32_t		cpusubtype;	/* machine specifier */
 	uint32_t	filetype;	/* type of file */
 	uint32_t	ncmds;		/* number of load commands */
 	uint32_t	sizeofcmds;	/* the size of all the load commands */
@@ -71,8 +71,8 @@ struct mach_header {
  */
 struct mach_header_64 {
 	uint32_t	magic;		/* mach magic number identifier */
-	cpu_type_t	cputype;	/* cpu specifier */
-	cpu_subtype_t	cpusubtype;	/* machine specifier */
+	int32_t		cputype;	/* cpu specifier */
+	int32_t		cpusubtype;	/* machine specifier */
 	uint32_t	filetype;	/* type of file */
 	uint32_t	ncmds;		/* number of load commands */
 	uint32_t	sizeofcmds;	/* the size of all the load commands */
@@ -115,11 +115,17 @@ struct mach_header_64 {
 #define	MH_DYLIB	0x6		/* dynamically bound shared library */
 #define	MH_DYLINKER	0x7		/* dynamic link editor */
 #define	MH_BUNDLE	0x8		/* dynamically bound bundle file */
-#define	MH_DYLIB_STUB	0x9		/* shared library stub for static */
-					/*  linking only, no section contents */
-#define	MH_DSYM		0xa		/* companion file with only debug */
-					/*  sections */
+#define	MH_DYLIB_STUB	0x9		/* shared library stub for static
+					   linking only, no section contents */
+#define	MH_DSYM		0xa		/* companion file with only debug
+					   sections */
 #define	MH_KEXT_BUNDLE	0xb		/* x86_64 kexts */
+#define MH_FILESET	0xc		/* a file composed of other Mach-Os to
+					   be run in the same userspace sharing
+					   a single linkedit. */
+#define	MH_GPU_EXECUTE	0xd		/* gpu program */
+#define	MH_GPU_DYLIB	0xe		/* gpu support functions */
+
 
 /* Constants for the flags field of the mach_header */
 #define	MH_NOUNDEFS	0x1		/* the object file has no undefined
@@ -217,10 +223,10 @@ struct mach_header_64 {
 
 #define	MH_SIM_SUPPORT 0x08000000	/* Allow LC_MIN_VERSION_MACOS and
 					   LC_BUILD_VERSION load commands with
-					   the platforms macOS, iOSMac,
+					   the platforms macOS, macCatalyst,
 					   iOSSimulator, tvOSSimulator and
 					   watchOSSimulator. */
-
+					   
 #define MH_DYLIB_IN_CACHE 0x80000000	/* Only for use on dylibs. When this bit
 					   is set, the dylib is part of the dyld
 					   shared cache, rather than loose in
@@ -322,6 +328,7 @@ struct load_command {
 #define LC_BUILD_VERSION 0x32 /* build for platform min OS version */
 #define LC_DYLD_EXPORTS_TRIE (0x33 | LC_REQ_DYLD) /* used with linkedit_data_command, payload is trie */
 #define LC_DYLD_CHAINED_FIXUPS (0x34 | LC_REQ_DYLD) /* used with linkedit_data_command */
+#define LC_FILESET_ENTRY (0x35 | LC_REQ_DYLD) /* used with fileset_entry_command */
 
 /*
  * A variable length string in a load command is represented by an lc_str
@@ -358,8 +365,8 @@ struct segment_command { /* for 32-bit architectures */
 	uint32_t	vmsize;		/* memory size of this segment */
 	uint32_t	fileoff;	/* file offset of this segment */
 	uint32_t	filesize;	/* amount to map from the file */
-	vm_prot_t	maxprot;	/* maximum VM protection */
-	vm_prot_t	initprot;	/* initial VM protection */
+	int32_t		maxprot;	/* maximum VM protection */
+	int32_t		initprot;	/* initial VM protection */
 	uint32_t	nsects;		/* number of sections in segment */
 	uint32_t	flags;		/* flags */
 };
@@ -378,8 +385,8 @@ struct segment_command_64 { /* for 64-bit architectures */
 	uint64_t	vmsize;		/* memory size of this segment */
 	uint64_t	fileoff;	/* file offset of this segment */
 	uint64_t	filesize;	/* amount to map from the file */
-	vm_prot_t	maxprot;	/* maximum VM protection */
-	vm_prot_t	initprot;	/* initial VM protection */
+	int32_t		maxprot;	/* maximum VM protection */
+	int32_t		initprot;	/* initial VM protection */
 	uint32_t	nsects;		/* number of sections in segment */
 	uint32_t	flags;		/* flags */
 };
@@ -1239,7 +1246,7 @@ struct version_min_command {
 };
 
 /*
- * The build_version_command contains the min OS version on which this
+ * The build_version_command contains the min OS version on which this 
  * binary was built to run for its platform.  The list of known platforms and
  * tool values following it.
  */
@@ -1259,6 +1266,8 @@ struct build_tool_version {
 };
 
 /* Known values for the platform field above. */
+#define PLATFORM_UNKNOWN 0
+#define PLATFORM_ANY 0xFFFFFFFF
 #define PLATFORM_MACOS 1
 #define PLATFORM_IOS 2
 #define PLATFORM_TVOS 3
@@ -1270,10 +1279,24 @@ struct build_tool_version {
 #define PLATFORM_WATCHOSSIMULATOR 9
 #define PLATFORM_DRIVERKIT 10
 
+#define PLATFORM_FIRMWARE 13
+#define PLATFORM_SEPOS 14
+
 /* Known values for the tool field above. */
 #define TOOL_CLANG 1
 #define TOOL_SWIFT 2
 #define TOOL_LD	3
+#define TOOL_LLD 4
+
+/* values for gpu tools (1024 to 1048) */
+#define TOOL_METAL                 1024
+#define TOOL_AIRLLD                1025
+#define TOOL_AIRNT                 1026
+#define TOOL_AIRNT_PLUGIN          1027
+#define TOOL_AIRPACK               1028
+#define TOOL_GPUARCHIVER           1031
+#define TOOL_METAL_FRAMEWORK       1032
+
 
 /*
  * The dyld_info_command contains the file offsets and sizes of 
@@ -1452,6 +1475,8 @@ struct dyld_info_command {
 #define EXPORT_SYMBOL_FLAGS_WEAK_DEFINITION			0x04
 #define EXPORT_SYMBOL_FLAGS_REEXPORT				0x08
 #define EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER			0x10
+#define EXPORT_SYMBOL_FLAGS_STATIC_RESOLVER			0x20
+
 
 /*
  * The linker_option_command contains linker options embedded in object files.
@@ -1569,6 +1594,21 @@ struct note_command {
     char	data_owner[16];	/* owner name for this LC_NOTE */
     uint64_t	offset;		/* file offset of this data */
     uint64_t	size;		/* length of data region */
+};
+
+/*
+ * LC_FILESET_ENTRY commands describe constituent Mach-O files that are part
+ * of a fileset. In one implementation, entries are dylibs with individual
+ * mach headers and repositionable text and data segments. Each entry is
+ * further described by its own mach header.
+ */
+struct fileset_entry_command {
+    uint32_t     cmd;        /* LC_FILESET_ENTRY */
+    uint32_t     cmdsize;    /* includes entry_id string */
+    uint64_t     vmaddr;     /* memory address of the entry */
+    uint64_t     fileoff;    /* file offset of the entry */
+    union lc_str entry_id;   /* contained entry id */
+    uint32_t     reserved;   /* reserved */
 };
 
 #endif /* _MACHO_LOADER_H_ */

--- a/Headers/mach-o/nlist.h
+++ b/Headers/mach-o/nlist.h
@@ -302,6 +302,12 @@ struct nlist_64 {
  */
 #define N_ALT_ENTRY 0x0200
 
+/*
+ * The N_COLD_FUNC bit of the n_desc field indicates that the symbol is used
+ * infrequently and the linker should order it towards the end of the section.
+ */
+#define N_COLD_FUNC 0x0400
+
 #ifndef __STRICT_BSD__
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Sync with Xcode 14.3 SDK in particular the new FILESET type and structures, useful to deal with latest kernel and kexts related files.