### PR TITLE
Update Availability Headers

### DIFF
--- a/Headers/Availability.h
+++ b/Headers/Availability.h
@@ -182,6 +182,10 @@
 
 #include <AvailabilityVersions.h>
 #include <AvailabilityInternal.h>
+#include <AvailabilityInternalLegacy.h>
+#if __has_include(<AvailabilityInternalPrivate.h>)
+  #include <AvailabilityInternalPrivate.h>
+#endif
 
 #ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
     #define __OSX_AVAILABLE_STARTING(_osx, _ios) __AVAILABILITY_INTERNAL##_ios
@@ -557,3 +561,4 @@
 #endif
 
 #endif /* __AVAILABILITY__ */
+

--- a/Headers/AvailabilityInternal.h
+++ b/Headers/AvailabilityInternal.h
@@ -36,7 +36,7 @@
     #if  __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__
         /* compiler for Mac OS X sets __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ */
         #define __MAC_OS_X_VERSION_MIN_REQUIRED __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__
-        #define __MAC_OS_X_VERSION_MAX_ALLOWED __MAC_15_0
+        #define __MAC_OS_X_VERSION_MAX_ALLOWED __MAC_15_2
     #endif
 #endif /* __MAC_OS_X_VERSION_MIN_REQUIRED */
 
@@ -44,11 +44,11 @@
     #if defined(__has_builtin) && __has_builtin(__is_target_os)
         #if __is_target_os(ios)
             #define __IPHONE_OS_VERSION_MIN_REQUIRED __ENVIRONMENT_OS_VERSION_MIN_REQUIRED__
-            #define __IPHONE_OS_VERSION_MAX_ALLOWED __IPHONE_18_0
+            #define __IPHONE_OS_VERSION_MAX_ALLOWED __IPHONE_18_2
         #endif
     #elif  __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ 
         #define __IPHONE_OS_VERSION_MIN_REQUIRED __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__
-        #define __IPHONE_OS_VERSION_MAX_ALLOWED __IPHONE_18_0
+        #define __IPHONE_OS_VERSION_MAX_ALLOWED __IPHONE_18_2
     #endif /*  __has_builtin(__is_target_os) && __is_target_os(ios) */
 #endif /* __IPHONE_OS_VERSION_MIN_REQUIRED */
 
@@ -56,13 +56,13 @@
     #if defined(__has_builtin) && __has_builtin(__is_target_os)
         #if __is_target_os(watchos)
             #define __WATCH_OS_VERSION_MIN_REQUIRED __ENVIRONMENT_OS_VERSION_MIN_REQUIRED__
-            #define __WATCH_OS_VERSION_MAX_ALLOWED __WATCHOS_11_0
+            #define __WATCH_OS_VERSION_MAX_ALLOWED __WATCHOS_11_2
             /* for compatibility with existing code.  New code should use platform specific checks */
             #define __IPHONE_OS_VERSION_MIN_REQUIRED __IPHONE_9_0
         #endif
     #elif  __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ 
         #define __WATCH_OS_VERSION_MIN_REQUIRED __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__
-        #define __WATCH_OS_VERSION_MAX_ALLOWED __WATCHOS_11_0
+        #define __WATCH_OS_VERSION_MAX_ALLOWED __WATCHOS_11_2
         /* for compatibility with existing code.  New code should use platform specific checks */
         #define __IPHONE_OS_VERSION_MIN_REQUIRED __IPHONE_9_0
     #endif /*  __has_builtin(__is_target_os) && __is_target_os(watchos) */
@@ -72,13 +72,13 @@
     #if defined(__has_builtin) && __has_builtin(__is_target_os)
         #if __is_target_os(tvos)
             #define __TV_OS_VERSION_MIN_REQUIRED __ENVIRONMENT_OS_VERSION_MIN_REQUIRED__
-            #define __TV_OS_VERSION_MAX_ALLOWED __TVOS_18_0
+            #define __TV_OS_VERSION_MAX_ALLOWED __TVOS_18_2
             /* for compatibility with existing code.  New code should use platform specific checks */
             #define __IPHONE_OS_VERSION_MIN_REQUIRED __IPHONE_9_0
         #endif
     #elif  __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ 
         #define __TV_OS_VERSION_MIN_REQUIRED __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__
-        #define __TV_OS_VERSION_MAX_ALLOWED __TVOS_18_0
+        #define __TV_OS_VERSION_MAX_ALLOWED __TVOS_18_2
         /* for compatibility with existing code.  New code should use platform specific checks */
         #define __IPHONE_OS_VERSION_MIN_REQUIRED __IPHONE_9_0
     #endif /*  __has_builtin(__is_target_os) && __is_target_os(tvos) */
@@ -88,7 +88,7 @@
     #if defined(__has_builtin) && __has_builtin(__is_target_os)
         #if __is_target_os(bridgeos)
             #define __BRIDGE_OS_VERSION_MIN_REQUIRED __ENVIRONMENT_OS_VERSION_MIN_REQUIRED__
-            #define __BRIDGE_OS_VERSION_MAX_ALLOWED __BRIDGEOS_9_0
+            #define __BRIDGE_OS_VERSION_MAX_ALLOWED __BRIDGEOS_9_2
             /* for compatibility with existing code.  New code should use platform specific checks */
             #define __IPHONE_OS_VERSION_MIN_REQUIRED __IPHONE_11_0
         #endif
@@ -99,7 +99,7 @@
     #if defined(__has_builtin) && __has_builtin(__is_target_os)
         #if __is_target_os(driverkit)
             #define __DRIVERKIT_VERSION_MIN_REQUIRED __ENVIRONMENT_OS_VERSION_MIN_REQUIRED__
-            #define __DRIVERKIT_VERSION_MAX_ALLOWED __DRIVERKIT_24_0
+            #define __DRIVERKIT_VERSION_MAX_ALLOWED __DRIVERKIT_24_2
         #endif
     #endif /*  __has_builtin(__is_target_os) && __is_target_os(driverkit) */
 #endif /* __DRIVERKIT_VERSION_MIN_REQUIRED */
@@ -108,7 +108,7 @@
     #if defined(__has_builtin) && __has_builtin(__is_target_os)
         #if __is_target_os(visionos)
             #define __VISION_OS_VERSION_MIN_REQUIRED __ENVIRONMENT_OS_VERSION_MIN_REQUIRED__
-            #define __VISION_OS_VERSION_MAX_ALLOWED __VISIONOS_2_0
+            #define __VISION_OS_VERSION_MAX_ALLOWED __VISIONOS_2_2
             /* for compatibility with existing code.  New code should use platform specific checks */
             #define __IPHONE_OS_VERSION_MIN_REQUIRED __IPHONE_17_1
         #endif

--- a/Headers/AvailabilityInternal.h
+++ b/Headers/AvailabilityInternal.h
@@ -30,15 +30,13 @@
 #ifndef __AVAILABILITY_INTERNAL__
 #define __AVAILABILITY_INTERNAL__
 
-#if __has_include(<AvailabilityInternalPrivate.h>)
-  #include <AvailabilityInternalPrivate.h>
-#endif
+#include <AvailabilityVersions.h>
 
 #ifndef __MAC_OS_X_VERSION_MIN_REQUIRED
     #if  __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__
         /* compiler for Mac OS X sets __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ */
         #define __MAC_OS_X_VERSION_MIN_REQUIRED __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__
-        #define __MAC_OS_X_VERSION_MAX_ALLOWED __MAC_14_5
+        #define __MAC_OS_X_VERSION_MAX_ALLOWED __MAC_15_0
     #endif
 #endif /* __MAC_OS_X_VERSION_MIN_REQUIRED */
 
@@ -46,11 +44,11 @@
     #if defined(__has_builtin) && __has_builtin(__is_target_os)
         #if __is_target_os(ios)
             #define __IPHONE_OS_VERSION_MIN_REQUIRED __ENVIRONMENT_OS_VERSION_MIN_REQUIRED__
-            #define __IPHONE_OS_VERSION_MAX_ALLOWED __IPHONE_17_5
+            #define __IPHONE_OS_VERSION_MAX_ALLOWED __IPHONE_18_0
         #endif
     #elif  __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ 
         #define __IPHONE_OS_VERSION_MIN_REQUIRED __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__
-        #define __IPHONE_OS_VERSION_MAX_ALLOWED __IPHONE_17_5
+        #define __IPHONE_OS_VERSION_MAX_ALLOWED __IPHONE_18_0
     #endif /*  __has_builtin(__is_target_os) && __is_target_os(ios) */
 #endif /* __IPHONE_OS_VERSION_MIN_REQUIRED */
 
@@ -58,13 +56,13 @@
     #if defined(__has_builtin) && __has_builtin(__is_target_os)
         #if __is_target_os(watchos)
             #define __WATCH_OS_VERSION_MIN_REQUIRED __ENVIRONMENT_OS_VERSION_MIN_REQUIRED__
-            #define __WATCH_OS_VERSION_MAX_ALLOWED __WATCHOS_10_5
+            #define __WATCH_OS_VERSION_MAX_ALLOWED __WATCHOS_11_0
             /* for compatibility with existing code.  New code should use platform specific checks */
             #define __IPHONE_OS_VERSION_MIN_REQUIRED __IPHONE_9_0
         #endif
     #elif  __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ 
         #define __WATCH_OS_VERSION_MIN_REQUIRED __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__
-        #define __WATCH_OS_VERSION_MAX_ALLOWED __WATCHOS_10_5
+        #define __WATCH_OS_VERSION_MAX_ALLOWED __WATCHOS_11_0
         /* for compatibility with existing code.  New code should use platform specific checks */
         #define __IPHONE_OS_VERSION_MIN_REQUIRED __IPHONE_9_0
     #endif /*  __has_builtin(__is_target_os) && __is_target_os(watchos) */
@@ -74,13 +72,13 @@
     #if defined(__has_builtin) && __has_builtin(__is_target_os)
         #if __is_target_os(tvos)
             #define __TV_OS_VERSION_MIN_REQUIRED __ENVIRONMENT_OS_VERSION_MIN_REQUIRED__
-            #define __TV_OS_VERSION_MAX_ALLOWED __TVOS_17_5
+            #define __TV_OS_VERSION_MAX_ALLOWED __TVOS_18_0
             /* for compatibility with existing code.  New code should use platform specific checks */
             #define __IPHONE_OS_VERSION_MIN_REQUIRED __IPHONE_9_0
         #endif
     #elif  __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ 
         #define __TV_OS_VERSION_MIN_REQUIRED __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__
-        #define __TV_OS_VERSION_MAX_ALLOWED __TVOS_17_5
+        #define __TV_OS_VERSION_MAX_ALLOWED __TVOS_18_0
         /* for compatibility with existing code.  New code should use platform specific checks */
         #define __IPHONE_OS_VERSION_MIN_REQUIRED __IPHONE_9_0
     #endif /*  __has_builtin(__is_target_os) && __is_target_os(tvos) */
@@ -90,7 +88,7 @@
     #if defined(__has_builtin) && __has_builtin(__is_target_os)
         #if __is_target_os(bridgeos)
             #define __BRIDGE_OS_VERSION_MIN_REQUIRED __ENVIRONMENT_OS_VERSION_MIN_REQUIRED__
-            #define __BRIDGE_OS_VERSION_MAX_ALLOWED __BRIDGEOS_8_5
+            #define __BRIDGE_OS_VERSION_MAX_ALLOWED __BRIDGEOS_9_0
             /* for compatibility with existing code.  New code should use platform specific checks */
             #define __IPHONE_OS_VERSION_MIN_REQUIRED __IPHONE_11_0
         #endif
@@ -101,7 +99,7 @@
     #if defined(__has_builtin) && __has_builtin(__is_target_os)
         #if __is_target_os(driverkit)
             #define __DRIVERKIT_VERSION_MIN_REQUIRED __ENVIRONMENT_OS_VERSION_MIN_REQUIRED__
-            #define __DRIVERKIT_VERSION_MAX_ALLOWED __DRIVERKIT_23_5
+            #define __DRIVERKIT_VERSION_MAX_ALLOWED __DRIVERKIT_24_0
         #endif
     #endif /*  __has_builtin(__is_target_os) && __is_target_os(driverkit) */
 #endif /* __DRIVERKIT_VERSION_MIN_REQUIRED */
@@ -110,7 +108,7 @@
     #if defined(__has_builtin) && __has_builtin(__is_target_os)
         #if __is_target_os(visionos)
             #define __VISION_OS_VERSION_MIN_REQUIRED __ENVIRONMENT_OS_VERSION_MIN_REQUIRED__
-            #define __VISION_OS_VERSION_MAX_ALLOWED __VISIONOS_1_2
+            #define __VISION_OS_VERSION_MAX_ALLOWED __VISIONOS_2_0
             /* for compatibility with existing code.  New code should use platform specific checks */
             #define __IPHONE_OS_VERSION_MIN_REQUIRED __IPHONE_17_1
         #endif
@@ -168,8 +166,6 @@
 #define __AVAILABILITY_INTERNAL_UNAVAILABLE           __attribute__((unavailable))
 #define __AVAILABILITY_INTERNAL_WEAK_IMPORT           __attribute__((weak_import))
 #define __AVAILABILITY_INTERNAL_REGULAR            
-
-#include <AvailabilityInternalLegacy.h>
 
 #if defined(__has_feature) && defined(__has_attribute)
  #if __has_attribute(availability)
@@ -315,6 +311,16 @@
     #define __API_DEPRECATED_BEGIN_REP7(msg,arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7) __API_R_BEGIN(msg,arg0) __API_R_BEGIN(msg,arg1) __API_R_BEGIN(msg,arg2) __API_R_BEGIN(msg,arg3) __API_R_BEGIN(msg,arg4) __API_R_BEGIN(msg,arg5) __API_R_BEGIN(msg,arg6) __API_R_BEGIN(msg,arg7)
     #define __API_DEPRECATED_BEGIN_REP8(msg,arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8) __API_R_BEGIN(msg,arg0) __API_R_BEGIN(msg,arg1) __API_R_BEGIN(msg,arg2) __API_R_BEGIN(msg,arg3) __API_R_BEGIN(msg,arg4) __API_R_BEGIN(msg,arg5) __API_R_BEGIN(msg,arg6) __API_R_BEGIN(msg,arg7) __API_R_BEGIN(msg,arg8)
     #define __API_DEPRECATED_BEGIN_REP_GET_MACRO(_0,_1,_2,_3,_4,_5,_6,_7,_8,_9,NAME,...) NAME
+    #define __API_DEPRECATED_WITH_REPLACEMENT_BEGIN0(msg,arg0) __API_R_BEGIN(msg,arg0)
+    #define __API_DEPRECATED_WITH_REPLACEMENT_BEGIN1(msg,arg0,arg1) __API_R_BEGIN(msg,arg0) __API_R_BEGIN(msg,arg1)
+    #define __API_DEPRECATED_WITH_REPLACEMENT_BEGIN2(msg,arg0,arg1,arg2) __API_R_BEGIN(msg,arg0) __API_R_BEGIN(msg,arg1) __API_R_BEGIN(msg,arg2)
+    #define __API_DEPRECATED_WITH_REPLACEMENT_BEGIN3(msg,arg0,arg1,arg2,arg3) __API_R_BEGIN(msg,arg0) __API_R_BEGIN(msg,arg1) __API_R_BEGIN(msg,arg2) __API_R_BEGIN(msg,arg3)
+    #define __API_DEPRECATED_WITH_REPLACEMENT_BEGIN4(msg,arg0,arg1,arg2,arg3,arg4) __API_R_BEGIN(msg,arg0) __API_R_BEGIN(msg,arg1) __API_R_BEGIN(msg,arg2) __API_R_BEGIN(msg,arg3) __API_R_BEGIN(msg,arg4)
+    #define __API_DEPRECATED_WITH_REPLACEMENT_BEGIN5(msg,arg0,arg1,arg2,arg3,arg4,arg5) __API_R_BEGIN(msg,arg0) __API_R_BEGIN(msg,arg1) __API_R_BEGIN(msg,arg2) __API_R_BEGIN(msg,arg3) __API_R_BEGIN(msg,arg4) __API_R_BEGIN(msg,arg5)
+    #define __API_DEPRECATED_WITH_REPLACEMENT_BEGIN6(msg,arg0,arg1,arg2,arg3,arg4,arg5,arg6) __API_R_BEGIN(msg,arg0) __API_R_BEGIN(msg,arg1) __API_R_BEGIN(msg,arg2) __API_R_BEGIN(msg,arg3) __API_R_BEGIN(msg,arg4) __API_R_BEGIN(msg,arg5) __API_R_BEGIN(msg,arg6)
+    #define __API_DEPRECATED_WITH_REPLACEMENT_BEGIN7(msg,arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7) __API_R_BEGIN(msg,arg0) __API_R_BEGIN(msg,arg1) __API_R_BEGIN(msg,arg2) __API_R_BEGIN(msg,arg3) __API_R_BEGIN(msg,arg4) __API_R_BEGIN(msg,arg5) __API_R_BEGIN(msg,arg6) __API_R_BEGIN(msg,arg7)
+    #define __API_DEPRECATED_WITH_REPLACEMENT_BEGIN8(msg,arg0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8) __API_R_BEGIN(msg,arg0) __API_R_BEGIN(msg,arg1) __API_R_BEGIN(msg,arg2) __API_R_BEGIN(msg,arg3) __API_R_BEGIN(msg,arg4) __API_R_BEGIN(msg,arg5) __API_R_BEGIN(msg,arg6) __API_R_BEGIN(msg,arg7) __API_R_BEGIN(msg,arg8)
+    #define __API_DEPRECATED_WITH_REPLACEMENT_BEGIN_GET_MACRO(_0,_1,_2,_3,_4,_5,_6,_7,_8,_9,NAME,...) NAME
 
     /*
      * API Unavailability
@@ -372,22 +378,6 @@
     #define __swift_compiler_version_at_least(...) __swift_compiler_version_at_least_impl(__VA_ARGS__, 0, 0, 0, 0)
 #else
     #define __swift_compiler_version_at_least(...) 1
-#endif
-
-/*
- * If __SPI_AVAILABLE has not been defined elsewhere, disable it.
- */
- 
-#ifndef __SPI_AVAILABLE
-  #define __SPI_AVAILABLE(...)
-#endif
-
-#ifndef __SPI_AVAILABLE_BEGIN
-  #define __SPI_AVAILABLE_BEGIN(...)
-#endif
-
-#ifndef __SPI_AVAILABLE_END
-  #define __SPI_AVAILABLE_END(...)
 #endif
 
 #endif /* __AVAILABILITY_INTERNAL__ */

--- a/Headers/AvailabilityInternalLegacy.h
+++ b/Headers/AvailabilityInternalLegacy.h
@@ -31,6 +31,8 @@
 #ifndef __AVAILABILITY_INTERNAL_LEGACY__
 #define __AVAILABILITY_INTERNAL_LEGACY__
 
+#include <AvailabilityInternal.h>
+
 #if defined(__has_builtin)
  #if __has_builtin(__is_target_arch)
   #if __has_builtin(__is_target_vendor)

--- a/Headers/AvailabilityMacros.h
+++ b/Headers/AvailabilityMacros.h
@@ -83,10 +83,11 @@
   
 */
 
-#include <AvailabilityVersions.h>
-
 #ifndef __AVAILABILITYMACROS__
 #define __AVAILABILITYMACROS__
+
+#include <AvailabilityVersions.h>
+#include <TargetConditionals.h>
 
 /* 
  * If min OS not specified, assume 10.4 for intel

--- a/Headers/AvailabilityVersions.h
+++ b/Headers/AvailabilityVersions.h
@@ -86,6 +86,7 @@
 #define __MAC_14_3                                      140300
 #define __MAC_14_4                                      140400
 #define __MAC_14_5                                      140500
+#define __MAC_15_0                                      150000
 /* __MAC__NA is not defined to a value but is used as a token by macros to indicate that the API is unavailable */
 
 #define __IPHONE_2_0                                     20000
@@ -168,6 +169,7 @@
 #define __IPHONE_17_3                                   170300
 #define __IPHONE_17_4                                   170400
 #define __IPHONE_17_5                                   170500
+#define __IPHONE_18_0                                   180000
 /* __IPHONE__NA is not defined to a value but is used as a token by macros to indicate that the API is unavailable */
 
 #define __WATCHOS_1_0                                    10000
@@ -217,6 +219,7 @@
 #define __WATCHOS_10_3                                  100300
 #define __WATCHOS_10_4                                  100400
 #define __WATCHOS_10_5                                  100500
+#define __WATCHOS_11_0                                  110000
 /* __WATCHOS__NA is not defined to a value but is used as a token by macros to indicate that the API is unavailable */
 
 #define __TVOS_9_0                                       90000
@@ -267,6 +270,7 @@
 #define __TVOS_17_3                                     170300
 #define __TVOS_17_4                                     170400
 #define __TVOS_17_5                                     170500
+#define __TVOS_18_0                                     180000
 /* __TVOS__NA is not defined to a value but is used as a token by macros to indicate that the API is unavailable */
 
 #define __BRIDGEOS_2_0                                   20000
@@ -296,6 +300,7 @@
 #define __BRIDGEOS_8_3                                   80300
 #define __BRIDGEOS_8_4                                   80400
 #define __BRIDGEOS_8_5                                   80500
+#define __BRIDGEOS_9_0                                   90000
 
 
 #define __DRIVERKIT_19_0                                190000
@@ -311,11 +316,13 @@
 #define __DRIVERKIT_23_3                                230300
 #define __DRIVERKIT_23_4                                230400
 #define __DRIVERKIT_23_5                                230500
+#define __DRIVERKIT_24_0                                240000
 /* __DRIVERKIT__NA is not defined to a value but is used as a token by macros to indicate that the API is unavailable */
 
 #define __VISIONOS_1_0                                   10000
 #define __VISIONOS_1_1                                   10100
 #define __VISIONOS_1_2                                   10200
+#define __VISIONOS_2_0                                   20000
 /* __VISIONOS__NA is not defined to a value but is used as a token by macros to indicate that the API is unavailable */
 
 
@@ -393,6 +400,7 @@
 #define  MAC_OS_VERSION_14_3                             __MAC_14_3
 #define  MAC_OS_VERSION_14_4                             __MAC_14_4
 #define  MAC_OS_VERSION_14_5                             __MAC_14_5
+#define  MAC_OS_VERSION_15_0                             __MAC_15_0
 
 #endif /* #if (!defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE)) || defined(_DARWIN_C_SOURCE) */
 

--- a/Headers/AvailabilityVersions.h
+++ b/Headers/AvailabilityVersions.h
@@ -87,6 +87,8 @@
 #define __MAC_14_4                                      140400
 #define __MAC_14_5                                      140500
 #define __MAC_15_0                                      150000
+#define __MAC_15_1                                      150100
+#define __MAC_15_2                                      150200
 /* __MAC__NA is not defined to a value but is used as a token by macros to indicate that the API is unavailable */
 
 #define __IPHONE_2_0                                     20000
@@ -170,6 +172,8 @@
 #define __IPHONE_17_4                                   170400
 #define __IPHONE_17_5                                   170500
 #define __IPHONE_18_0                                   180000
+#define __IPHONE_18_1                                   180100
+#define __IPHONE_18_2                                   180200
 /* __IPHONE__NA is not defined to a value but is used as a token by macros to indicate that the API is unavailable */
 
 #define __WATCHOS_1_0                                    10000
@@ -220,6 +224,8 @@
 #define __WATCHOS_10_4                                  100400
 #define __WATCHOS_10_5                                  100500
 #define __WATCHOS_11_0                                  110000
+#define __WATCHOS_11_1                                  110100
+#define __WATCHOS_11_2                                  110200
 /* __WATCHOS__NA is not defined to a value but is used as a token by macros to indicate that the API is unavailable */
 
 #define __TVOS_9_0                                       90000
@@ -271,6 +277,8 @@
 #define __TVOS_17_4                                     170400
 #define __TVOS_17_5                                     170500
 #define __TVOS_18_0                                     180000
+#define __TVOS_18_1                                     180100
+#define __TVOS_18_2                                     180200
 /* __TVOS__NA is not defined to a value but is used as a token by macros to indicate that the API is unavailable */
 
 #define __BRIDGEOS_2_0                                   20000
@@ -301,6 +309,8 @@
 #define __BRIDGEOS_8_4                                   80400
 #define __BRIDGEOS_8_5                                   80500
 #define __BRIDGEOS_9_0                                   90000
+#define __BRIDGEOS_9_1                                   90100
+#define __BRIDGEOS_9_2                                   90200
 
 
 #define __DRIVERKIT_19_0                                190000
@@ -317,12 +327,16 @@
 #define __DRIVERKIT_23_4                                230400
 #define __DRIVERKIT_23_5                                230500
 #define __DRIVERKIT_24_0                                240000
+#define __DRIVERKIT_24_1                                240100
+#define __DRIVERKIT_24_2                                240200
 /* __DRIVERKIT__NA is not defined to a value but is used as a token by macros to indicate that the API is unavailable */
 
 #define __VISIONOS_1_0                                   10000
 #define __VISIONOS_1_1                                   10100
 #define __VISIONOS_1_2                                   10200
 #define __VISIONOS_2_0                                   20000
+#define __VISIONOS_2_1                                   20100
+#define __VISIONOS_2_2                                   20200
 /* __VISIONOS__NA is not defined to a value but is used as a token by macros to indicate that the API is unavailable */
 
 
@@ -401,6 +415,8 @@
 #define  MAC_OS_VERSION_14_4                             __MAC_14_4
 #define  MAC_OS_VERSION_14_5                             __MAC_14_5
 #define  MAC_OS_VERSION_15_0                             __MAC_15_0
+#define  MAC_OS_VERSION_15_1                             __MAC_15_1
+#define  MAC_OS_VERSION_15_2                             __MAC_15_2
 
 #endif /* #if (!defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE)) || defined(_DARWIN_C_SOURCE) */
 


### PR DESCRIPTION
Update the Availability headers using the ones from Xcode 16.2 Beta (build 16B5100e)

Edits to the headers include:
- Reverting the `__MAC_OS_X_VERSION_MIN_REQUIRED ` change
- Retaining definitions of `__API_DEPRECATED_BEGIN_REP<X>`