### PR TITLE
Availability check some IOHID headers

### DIFF
--- a/Headers/IOKit/hid/IOHIDDevice.h
+++ b/Headers/IOKit/hid/IOHIDDevice.h
@@ -326,6 +326,7 @@ public:
 
     virtual IOReturn message( UInt32 type, IOService * provider,  void * argument = 0 ) APPLE_KEXT_OVERRIDE;
 
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_11_0
     using IOService::setProperty;
 /*! @function setProperty
     @abstract Synchronized method to add a property to an IOHIDDevice's property table.
@@ -335,6 +336,7 @@ public:
     @result true on success or false on a resource failure. */
 
     virtual bool setProperty( const OSSymbol * aKey, OSObject * anObject) APPLE_KEXT_OVERRIDE;
+#endif
 
 /*! @function newTransportString
     @abstract Returns a string object that describes the transport

--- a/Headers/IOKit/hid/IOHIDEventService.h
+++ b/Headers/IOKit/hid/IOHIDEventService.h
@@ -621,6 +621,7 @@ protected:
                                 IOFixed                         azimuth         = 0,
                                 IOOptionBits                    options         = 0 );
     
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_10
     /*!
      @function dispatchUnicodeEvent
      @abstract Dispatch unicode events
@@ -652,6 +653,10 @@ protected:
                                                  IOOptionBits               options     = 0);
 
     
+#else
+    OSMetaClassDeclareReservedUnused(IOHIDEventService,  6);
+#endif
+
 private:
     enum {
         kDigitizerOrientationTypeTilt = 0,
@@ -678,6 +683,7 @@ private:
                                 IOOptionBits                    options                 = 0 );
     
 
+#if TARGET_OS_EMBEDDED || __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_12
 public:
     typedef void (*Action)(OSObject *target, OSObject * sender, void *context, OSObject *event, IOOptionBits options);
 
@@ -788,6 +794,18 @@ protected:
                                                                 IOFixed                         joystickZ,
                                                                 IOFixed                         joystickRz,
                                                                 IOOptionBits                    options         = 0 );
+    
+
+#else
+protected:
+    OSMetaClassDeclareReservedUnused(IOHIDEventService,  7);
+    OSMetaClassDeclareReservedUnused(IOHIDEventService,  8);
+    OSMetaClassDeclareReservedUnused(IOHIDEventService,  9);
+    OSMetaClassDeclareReservedUnused(IOHIDEventService, 10);
+    OSMetaClassDeclareReservedUnused(IOHIDEventService, 11);
+    OSMetaClassDeclareReservedUnused(IOHIDEventService, 12);
+    OSMetaClassDeclareReservedUnused(IOHIDEventService, 13);
+#endif
     
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_12
     /*!

--- a/Headers/IOKit/hid/IOHIDEventService.h
+++ b/Headers/IOKit/hid/IOHIDEventService.h
@@ -683,7 +683,7 @@ private:
                                 IOOptionBits                    options                 = 0 );
     
 
-#if TARGET_OS_EMBEDDED || __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_12
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_12
 public:
     typedef void (*Action)(OSObject *target, OSObject * sender, void *context, OSObject *event, IOOptionBits options);
 
@@ -958,7 +958,9 @@ protected:
     OSMetaClassDeclareReservedUnused(IOHIDEventService, 31);
 
 public:
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_12
     virtual void            close( IOService * forClient, IOOptionBits options = 0 ) APPLE_KEXT_OVERRIDE;
+#endif
     
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_15
     /*! @function message


### PR DESCRIPTION
These changes were required to produce a loadable kext on my nearly-complete but not yet published implementation of the Wellspring trackpad protocol for VoodooInput, theoretically allowing trackpad support all the way back to 10.5 I believe. These are only from what kextutil/kextload complain about on 10.9.5 so I may need to gate more when I actually get earlier versions running for testing

Changes:

IOHIDEventService.h:
- gate dispatchUnicodeEvent gated to 10.10 and later
- gate Action function pointer definition, open, dispatchEvent, getPrimaryUsagePage, getPrimaryUsage, copyEvent, dispatchStandardGameControllerEvent, dispatchStandardGameControllerEvent, close to 10.12 and later

IOHIDDevice.h:
- gate setProperty to 11.0 and later
